### PR TITLE
Create mm-qcamerad.te

### DIFF
--- a/sepolicy/mm-qcamerad.te
+++ b/sepolicy/mm-qcamerad.te
@@ -1,0 +1,8 @@
+allow mm-qcamerad qdsp_device:chr_file { open read ioctl };
+allow mm-qcamerad system_server:unix_stream_socket { read write };
+allow servicemanager mm-qcamerad:dir search;
+allow servicemanager mm-qcamerad:file { open read };
+allow servicemanager mm-qcamerad:process { getattr };
+binder_call(mm-qcamerad, servicemanager)
+binder_call(mm-qcamerad, system_server)
+unix_socket_connect(mm-qcamerad, mpctl, mpdecision)


### PR DESCRIPTION
This fixes dmesg line 
<4>[   88.448850] type=1400 audit(1441291456.324:192): avc: denied { read } for pid=3873 comm="mm-qcamera-daem" name="adsprpc-smd" dev="tmpfs" ino=8802 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:qdsp_device:s0 tclass=chr_file

found in https://github.com/CyanogenMod/android_device_motorola_msm8226-common/blob/cm-12.1/sepolicy/mm-qcamerad.te
